### PR TITLE
Updates to MnvHnDToCSV

### DIFF
--- a/PlotUtils/MnvH1D.cxx
+++ b/PlotUtils/MnvH1D.cxx
@@ -3242,33 +3242,33 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
   
   
   
-  f_values->open((directory+name+"_1d.csv").c_str());
-  f_err->open((directory+name+"_errors_1d.csv").c_str());
-  f_staterr->open((directory+name+"_staterrors_1d.csv").c_str());
-  f_syserr->open((directory+name+"_syserrors_1d.csv").c_str());
-  f_bins->open((directory+name+"_bins_1d.csv").c_str());
-  f_corr->open((directory+name+"_correlation.csv").c_str());
-  f_cov->open((directory+name+"_covariance.csv").c_str());
+  f_values->open((directory+"/"+name+"values_1d.csv").c_str());
+  f_err->open((directory+"/"+name+"_errors_1d.csv").c_str());
+  f_staterr->open((directory+"/"+name+"_staterrors_1d.csv").c_str());
+  f_syserr->open((directory+"/"+name+"_syserrors_1d.csv").c_str());
+  f_bins->open((directory+"/"+name+"_bins_1d.csv").c_str());
+  f_corr->open((directory+"/"+name+"_correlation.csv").c_str());
+  f_cov->open((directory+"/"+name+"_covariance.csv").c_str());
+  std::ofstream *f_meta = new std::ofstream();
+  f_meta->open((directory+"/"+name+"_meta.txt").c_str());
+  *f_meta << "Name: " <<  name << std::endl;
+  *f_meta << Form("GetName: \"%s\"",GetName())<< std::endl;
+  *f_meta << Form("GetTitle: \"%s\"",GetTitle()) << std::endl;
+  *f_meta << Form("Fractional Errors: \"%d\"",percentage) << std::endl;
+  *f_meta << Form("Binwidth: \"%d\"",binwidth) << std::endl;
+  *f_meta << Form("SysErrors: \"%d\"",syserrors) << std::endl;
+  *f_meta << Form("Scale: \"%.17e\"",scale) << std::endl;
+  *f_meta << Form("Precision: \"%d\"",fullprecision) << std::endl;
+  *f_meta << Form("xAxis: \"%s\"",GetXaxis()->GetTitle()) << std::endl;
+  *f_meta << Form("yAxis: \"%s\"",GetYaxis()->GetTitle()) << std::endl;
+  f_meta->close();
   
   TH1D stat=GetStatError(); //stat error
   TH1D total=GetCVHistoWithError(); // CV with total error
   TH1D sys=GetTotalError(false); //sys error only
   
   //    *f_bins<<GetXaxis()->GetBinLowEdge(1); //<<std::endl;
-  *f_bins<<"Bins  \t" << GetName();
-  /*
-  *f_values << "Values\t"<< GetName();
-  *f_err << "err\t"<< GetName();
-  *f_staterr << "staterr\t"<< GetName();
-  *f_syserr << "syserr\t"<< GetName();
-  
-  
-  *f_bins << std::endl;
-  *f_values << std::endl;
-  *f_err << std::endl;
-  *f_staterr << std::endl;
-  *f_syserr << std::endl;
-  */
+  *f_bins<< Form("\"%s\"",GetTitle())<<",";
   *f_bins<<GetXaxis()->GetBinLowEdge(1)<< ","; //<<std::endl;
   if(fullprecision){
     
@@ -3296,14 +3296,6 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
       }
   }
   else{
-    //    *f_bins<<GetXaxis()->GetBinLowEdge(1); //<<std::endl;
-    /**f_bins<<"Bins\t";
-     *f_bins<<GetXaxis()->GetBinLowEdge(1)<< "\t"; //<<std::endl;
-     *f_values << "Values\t";
-     *f_err << "err\t";
-     *f_staterr << "staterr\t";
-     *f_syserr << "syserr\t";
-     */
     
     for (int i=1;i<=GetXaxis()->GetNbins();i++)
       {
@@ -3316,7 +3308,6 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
       }
       double bincor = 1.0;
       if (binwidth) bincor = (GetXaxis()->GetBinWidth(i));
-         
       *f_bins<<GetXaxis()->GetBinUpEdge(i);//<<std::endl;
       // Bin width normalize if not enu when we want a total x sec
       *f_values<<Form("%.2f",total.GetBinContent(i)/bincor*scale);
@@ -3340,7 +3331,7 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
   //    TMatrixD correlation_matrix= GetTotalCorrelationMatrix();
   TMatrixD correlation_matrix= GetTotalCorrelationMatrix();
   TMatrixD covariance_matrix= GetTotalErrorMatrix();
-  correlation_matrix *= (scale*scale); // scale by factor of 10^41
+  //correlation_matrix *= (scale*scale); // scale by factor of 10^41
   
   int nbins_x=GetNbinsX();
   
@@ -3373,8 +3364,8 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
       if (this_x > 1) *f_corr << ",";
       if (this_x > 1) *f_cov << ",";
       if(!fullprecision){
-        *f_cov<<Form("%.2e",covariance_matrix[x][this_x]/binwidcorri/binwidcorrj);
-        *f_corr<<Form("%.2e",correlation_matrix[x][this_x]);
+        *f_cov<<Form("%.2f",covariance_matrix[x][this_x]/binwidcorri/binwidcorrj);
+        *f_corr<<Form("%.4f",correlation_matrix[x][this_x]);
       }
       else{
         *f_cov<<Form("%.17e",covariance_matrix[x][this_x]/binwidcorri/binwidcorrj);
@@ -3400,9 +3391,9 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
   std::ofstream * f_lat = new std::ofstream();
   std::ofstream * f_vert = new std::ofstream();
   f_cov = new std::ofstream(); // reuse the name, sorry
-  f_lat->open((directory+name+"_latdump.csv").c_str());
-  f_vert->open((directory+name+"_vertdump.csv").c_str());
-  f_cov->open((directory+name+"_covdump.csv").c_str());
+  f_lat->open((directory+"/"+name+"_latdump.csv").c_str());
+  f_vert->open((directory+"/"+name+"_vertdump.csv").c_str());
+  f_cov->open((directory+"/"+name+"_covdump.csv").c_str());
   std::vector<std::string> vert_errBandNames = GetVertErrorBandNames();
   std::vector<std::string> lat_errBandNames  = GetLatErrorBandNames();
   std::vector<std::string> uncorr_errBandNames  = GetUncorrErrorNames();
@@ -3413,7 +3404,7 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
     unsigned int nunis = v->GetNHists();
     
     for (unsigned int i = 0; i< nunis; i++){
-        *f_vert <<GetName() << Form(" %s_%d,",name->c_str(),i);// << std::endl;
+        *f_vert << Form("%s_%d, ",name->c_str(),i);// << std::endl;
       TH1* h = v->GetHist(i);
       for (int j=1;j <=h->GetXaxis()->GetNbins();j++)
         {
@@ -3422,7 +3413,12 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
         }
         double bincor = 1.0;
         if(binwidth) bincor = h->GetXaxis()->GetBinWidth(j);
-            if(percentage) bincor = total.GetBinContent(j);
+        if(percentage){
+            bincor = total.GetBinContent(j);
+        }
+        else{
+          bincor = bincor/scale;
+        }
         double frac= (h->GetBinContent(j)/bincor);
         if (!fullprecision){
         *f_vert<<Form("%.2f",frac);
@@ -3443,7 +3439,7 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
     unsigned int nunis = v->GetNHists();
     
     for (unsigned int i = 0; i< nunis; i++){
-        *f_lat << GetName() << Form(" %s_%d,",name->c_str(),i) ; //<< std::endl;
+        *f_lat  << Form("%s_%d, ",name->c_str(),i) ; //<< std::endl;
       TH1* h = v->GetHist(i);
       for (int j=1;j <=h->GetXaxis()->GetNbins();j++)
         {
@@ -3453,7 +3449,12 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
 
         double bincor = 1.0;
         if(binwidth) bincor = h->GetXaxis()->GetBinWidth(j);
-        if(percentage) bincor = total.GetBinContent(j);
+          if(percentage){
+              bincor = total.GetBinContent(j);
+          }
+          else{
+            bincor = bincor/scale;
+          }
         double frac = (h->GetBinContent(j)/bincor);
         if (!fullprecision){
           *f_lat<<Form("%.2f",frac);
@@ -3471,7 +3472,7 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
   *f_cov << " covariance " << cov_errNames.size() <<  std::endl;
   for( std::vector<std::string>::iterator name=cov_errNames.begin(); name!=cov_errNames.end(); ++name ){
     TMatrixD  v = GetSysErrorMatrix(*name);
-    *f_cov << GetName() << Form(" %s",name->c_str()) << std::endl;
+    *f_cov << Form("%s, ",name->c_str()) << std::endl;
     int nbins_x = GetXaxis()->GetNbins();
     int totalbins=(nbins_x+2);
     

--- a/PlotUtils/MnvH1D.cxx
+++ b/PlotUtils/MnvH1D.cxx
@@ -3228,9 +3228,9 @@ void MnvH1D::SetBit(UInt_t f, Bool_t set)
 }
 
 
-void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, bool fullprecision, bool syserrors, bool percentage, bool binwidth){
+void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, bool fullprecision, bool syserrors, bool fractional, bool binwidth){
   
-  //std::cout << "entering 1DToCSV " << name << " scale = " << scale << " percentage = " << percentage << " binwidth = " << binwidth << std::endl;
+  //std::cout << "entering 1DToCSV " << name << " scale = " << scale << " fractional = " << fractional << " binwidth = " << binwidth << std::endl;
 
   std::ofstream *f_values =new std::ofstream();
   std::ofstream *f_err =new std::ofstream();
@@ -3242,22 +3242,22 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
   
   
   
-  f_values->open((directory+"/"+name+"values_1d.csv").c_str());
+  f_values->open((directory+"/"+name+"_values_1d.csv").c_str());
   f_err->open((directory+"/"+name+"_errors_1d.csv").c_str());
   f_staterr->open((directory+"/"+name+"_staterrors_1d.csv").c_str());
   f_syserr->open((directory+"/"+name+"_syserrors_1d.csv").c_str());
   f_bins->open((directory+"/"+name+"_bins_1d.csv").c_str());
-  f_corr->open((directory+"/"+name+"_correlation.csv").c_str());
-  f_cov->open((directory+"/"+name+"_covariance.csv").c_str());
+  f_corr->open((directory+"/"+name+"_correlation_1d.csv").c_str());
+  f_cov->open((directory+"/"+name+"_covariance_1d.csv").c_str());
   std::ofstream *f_meta = new std::ofstream();
-  f_meta->open((directory+"/"+name+"_meta.txt").c_str());
+  f_meta->open((directory+"/"+name+"_meta_1d.txt").c_str());
   *f_meta << "Name: " <<  name << std::endl;
   *f_meta << Form("GetName: \"%s\"",GetName())<< std::endl;
   *f_meta << Form("GetTitle: \"%s\"",GetTitle()) << std::endl;
-  *f_meta << Form("Fractional Errors: \"%d\"",percentage) << std::endl;
+  *f_meta << Form("Fractional Errors: \"%d\"",fractional) << std::endl;
   *f_meta << Form("Binwidth: \"%d\"",binwidth) << std::endl;
   *f_meta << Form("SysErrors: \"%d\"",syserrors) << std::endl;
-  *f_meta << Form("Scale: \"%.17e\"",scale) << std::endl;
+  *f_meta << Form("Scale: \"%.4e\"",scale) << std::endl;
   *f_meta << Form("Precision: \"%d\"",fullprecision) << std::endl;
   *f_meta << Form("xAxis: \"%s\"",GetXaxis()->GetTitle()) << std::endl;
   *f_meta << Form("yAxis: \"%s\"",GetYaxis()->GetTitle()) << std::endl;
@@ -3364,11 +3364,11 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
       if (this_x > 1) *f_corr << ",";
       if (this_x > 1) *f_cov << ",";
       if(!fullprecision){
-        *f_cov<<Form("%.2f",covariance_matrix[x][this_x]/binwidcorri/binwidcorrj);
+        *f_cov<<Form("%.2f",covariance_matrix[x][this_x]/binwidcorri/binwidcorrj*scale*scale);
         *f_corr<<Form("%.4f",correlation_matrix[x][this_x]);
       }
       else{
-        *f_cov<<Form("%.17e",covariance_matrix[x][this_x]/binwidcorri/binwidcorrj);
+        *f_cov<<Form("%.17e",covariance_matrix[x][this_x]/binwidcorri/binwidcorrj*scale*scale);
         *f_corr<<Form("%.17e",correlation_matrix[x][this_x]);
       }
       // need to include bin widths
@@ -3391,9 +3391,9 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
   std::ofstream * f_lat = new std::ofstream();
   std::ofstream * f_vert = new std::ofstream();
   f_cov = new std::ofstream(); // reuse the name, sorry
-  f_lat->open((directory+"/"+name+"_latdump.csv").c_str());
-  f_vert->open((directory+"/"+name+"_vertdump.csv").c_str());
-  f_cov->open((directory+"/"+name+"_covdump.csv").c_str());
+  f_lat->open((directory+"/"+name+"_latdump_1d").c_str());
+  f_vert->open((directory+"/"+name+"_vertdump_1d.csv").c_str());
+  f_cov->open((directory+"/"+name+"_covdump_1d.csv").c_str());
   std::vector<std::string> vert_errBandNames = GetVertErrorBandNames();
   std::vector<std::string> lat_errBandNames  = GetLatErrorBandNames();
   std::vector<std::string> uncorr_errBandNames  = GetUncorrErrorNames();
@@ -3413,7 +3413,7 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
         }
         double bincor = 1.0;
         if(binwidth) bincor = h->GetXaxis()->GetBinWidth(j);
-        if(percentage){
+        if(fractional){
             bincor = total.GetBinContent(j);
         }
         else{
@@ -3449,7 +3449,7 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
 
         double bincor = 1.0;
         if(binwidth) bincor = h->GetXaxis()->GetBinWidth(j);
-          if(percentage){
+          if(fractional){
               bincor = total.GetBinContent(j);
           }
           else{
@@ -3481,7 +3481,7 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
       double binwidcorri;
         binwidcorri = 1.0;
       if(binwidth) binwidcorri = GetXaxis()->GetBinWidth(x);
-      if(percentage) binwidcorri = GetBinContent(x)*scale;
+      if(fractional) binwidcorri = GetBinContent(x)*scale;
       if (x==0 ||  x==nbins_x+1 ) continue; // Do not print overflow and underflow
       
       for (int this_x=0;this_x<totalbins;this_x++)
@@ -3491,11 +3491,11 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
         double binwidcorrj;
             binwidcorrj = 1.0;
         if(binwidth) binwidcorrj = GetXaxis()->GetBinWidth(this_x);
-            if(percentage) binwidcorrj = GetBinContent(this_x)*scale;
+            if(fractional) binwidcorrj = GetBinContent(this_x)*scale;
         if (this_x > 1) *f_cov << ",";
         
         if(!fullprecision){
-          *f_cov<<Form("%.2f",v[x][this_x]/binwidcorri/binwidcorrj*scale*scale);
+          *f_cov<<Form("%.4f",v[x][this_x]/binwidcorri/binwidcorrj*scale*scale);
         }
         else{
         *f_cov<<Form("%.17e",v[x][this_x]/binwidcorri/binwidcorrj*scale*scale);

--- a/PlotUtils/MnvH1D.cxx
+++ b/PlotUtils/MnvH1D.cxx
@@ -3285,10 +3285,12 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
       }
       double bincor = 1.0;
       if (binwidth) bincor = (GetXaxis()->GetBinWidth(i));
+      
          
       // Bin width normalize if not enu when we want a total x sec
       *f_bins<<GetXaxis()->GetBinUpEdge(i);//<<std::endl;
       *f_values<<Form("%.17e",total.GetBinContent(i)/bincor*scale);
+      if (fractional) bincor = total.GetBinContent(i)*scale;
       *f_err<<Form("%.17e",total.GetBinError(i)/bincor*scale);
       *f_staterr<<Form("%.17e",stat.GetBinContent(i)/bincor*scale);
       *f_syserr<<Form("%.17e",sys.GetBinContent(i)/bincor*scale);
@@ -3310,7 +3312,9 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
       if (binwidth) bincor = (GetXaxis()->GetBinWidth(i));
       *f_bins<<GetXaxis()->GetBinUpEdge(i);//<<std::endl;
       // Bin width normalize if not enu when we want a total x sec
+      
       *f_values<<Form("%.2f",total.GetBinContent(i)/bincor*scale);
+      if (fractional) bincor = total.GetBinContent(i)*scale;
       *f_err<<Form("%.2f",total.GetBinError(i)/bincor*scale);
       *f_staterr<<Form("%.2f",stat.GetBinContent(i)/bincor*scale);
       *f_syserr<<Form("%.2f",sys.GetBinContent(i)/bincor*scale);

--- a/PlotUtils/MnvH2D.cxx
+++ b/PlotUtils/MnvH2D.cxx
@@ -1833,14 +1833,28 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
     
     
     
-    f_values->open((directory+name+".csv").c_str());
-    f_err->open((directory+name+"_errors.csv").c_str());
-    f_staterr->open((directory+name+"_staterrors.csv").c_str());
-    f_syserr->open((directory+name+"_syserrors.csv").c_str());
-    f_bins->open((directory+name+"_bins.csv").c_str());
-    f_corr->open((directory+name+"_correlation.csv").c_str());
-    f_cov->open((directory+name+"_covariance.csv").c_str());
-    
+    f_values->open((directory+"/"+name+"_values_2d.csv").c_str());
+    f_err->open((directory+"/"+name+"_errors_2d.csv").c_str());
+    f_staterr->open((directory+"/"+name+"_staterrors_2d.csv").c_str());
+    f_syserr->open((directory+"/"+name+"_syserrors_2d.csv").c_str());
+    f_bins->open((directory+"/"+name+"_bins_2d.csv").c_str());
+    f_corr->open((directory+"/"+name+"_correlation.csv").c_str());
+    f_cov->open((directory+"/"+name+"_covariance.csv").c_str());
+  
+  std::ofstream *f_meta = new std::ofstream();
+  f_meta->open((directory+"/"+name+"_meta.txt").c_str());
+  *f_meta << "Name: " <<  name << std::endl;
+  *f_meta << Form("GetName: \"%s\"",GetName())<< std::endl;
+  *f_meta << Form("GetTitle: \"%s\"",GetTitle()) << std::endl;
+  *f_meta << Form("Fractional Errors: \"%d\"",percentage) << std::endl;
+  *f_meta << Form("Binwidth: \"%d\"",binwidth) << std::endl;
+  *f_meta << Form("SysErrors: \"%d\"",syserrors) << std::endl;
+  *f_meta << Form("Scale: \"%.17e\"",scale) << std::endl;
+  *f_meta << Form("Precision: \"%d\"",fullprecision) << std::endl;
+  *f_meta << Form("xAxis: \"%s\"",GetXaxis()->GetTitle()) << std::endl;
+  *f_meta << Form("yAxis: \"%s\"",GetYaxis()->GetTitle()) << std::endl;
+  *f_meta << Form("zAxis: \"%s\"",GetZaxis()->GetTitle()) << std::endl;
+  f_meta->close();
     
     TH2D stat=GetStatError(); //stat error
     TH2D total=GetCVHistoWithError(); // CV with total error
@@ -1859,11 +1873,12 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
     *f_staterr<<std::endl;
     *f_syserr<<std::endl;
     */
-    
+    *f_bins<<Form("\"%s\"",GetXaxis()->GetTitle())<< ",";
     *f_bins<<GetXaxis()->GetBinLowEdge(1)<< ","; //<<std::endl;
     
     for (int x=1;x<=GetXaxis()->GetNbins();x++){
-        *f_bins<<GetXaxis()->GetBinUpEdge(x)<< ",";//<<std::endl;
+        *f_bins<<GetXaxis()->GetBinUpEdge(x);
+        if (x != GetXaxis()->GetNbins()) *f_bins  << ",";//<<std::endl;
         for (int y=1;y<=GetYaxis()->GetNbins();y++){
             if (y> 1) {
                 *f_values<<",";
@@ -1899,6 +1914,7 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
     }
     
     *f_bins<< std::endl;
+    *f_bins<< Form("\"%s\"",GetYaxis()->GetTitle())<< ",";
     for (int y=0;y<=GetYaxis()->GetNbins();y++){
         if (y!=0) *f_bins<< ",";
         *f_bins<<GetYaxis()->GetBinUpEdge(y);
@@ -1914,8 +1930,7 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
     //    TMatrixD correlation_matrix= GetTotalCorrelationMatrix();
     TMatrixD correlation_matrix= GetTotalCorrelationMatrix();
     TMatrixD covariance_matrix= GetTotalErrorMatrix();
-    correlation_matrix *= (scale*scale); // scale by factor of 10^41
-   // *f_corr << "Covariance" << std::endl;
+    //correlation_matrix *= (scale*scale);
     
     int nbins_x=GetNbinsX();
     int nbins_y=GetNbinsY();
@@ -1929,9 +1944,6 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
         
         binwidcorri = GetXaxis()->GetBinWidth(x)*GetYaxis()->GetBinWidth(y);
         if (!binwidth) binwidcorri = 1.0;
-        
-        
-        
         if (x==0 || y==0 || x==nbins_x+1 || y== nbins_y+1) continue; // Do not print overflow and underflow
         
         //*f_corr<< "bin_"<<x<<"_"<<y;
@@ -1955,12 +1967,12 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
             }
             if (!binwidth) binwidcorrj = 1.0;
             if (!fullprecision){
-                *f_cov<<Form("%.2e",covariance_matrix[i][j]/binwidcorri/binwidcorrj);   // need to include bin widths
-                *f_corr<<Form("%.2e",correlation_matrix[i][j]);   // do not include bin widths
+                *f_cov<<Form("%.2f",covariance_matrix[i][j]/binwidcorri/binwidcorrj*scale*scale);   // need to include bin widths
+                *f_corr<<Form("%.4f",correlation_matrix[i][j]);   // do not include bin widths
             }
             else{
-                *f_cov<<Form("%.17e",covariance_matrix[i][j]/binwidcorri/binwidcorrj);   // need to include bin widths
-                *f_corr<<Form("%.2e",correlation_matrix[i][j]);   // do not include bin widths
+                *f_cov<<Form("%.17e",covariance_matrix[i][j]/binwidcorri/binwidcorrj*scale*scale);   // need to include bin widths
+                *f_corr<<Form("%.17e",correlation_matrix[i][j]);   // do not include bin widths
             }
         }
         *f_corr<<std::endl;
@@ -1979,9 +1991,9 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
     std::ofstream * f_vert = new std::ofstream();
     std::ofstream * f_lat = new std::ofstream();
     f_cov = new std::ofstream();
-    f_lat->open((directory+name+"_latdump.csv").c_str());
-    f_vert->open((directory+name+"_vertdump.csv").c_str());
-    f_cov->open((directory+name+"_covdump.csv").c_str());
+    f_lat->open((directory+"/"+name+"_latdump.csv").c_str());
+    f_vert->open((directory+"/"+name+"_vertdump.csv").c_str());
+    f_cov->open((directory+"/"+name+"_covdump.csv").c_str());
     
     std::vector<std::string> vert_errBandNames = GetVertErrorBandNames();
     std::vector<std::string> lat_errBandNames  = GetLatErrorBandNames();
@@ -1993,7 +2005,7 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
         unsigned int nunis = v->GetNHists();
         
         for (unsigned int i = 0; i< nunis; i++){
-            *f_vert <<GetName() << Form(" %s_%d,",name->c_str(),i);// << std::endl;
+            *f_vert  << Form("%s_%d,",name->c_str(),i);// << std::endl;
             TH2* h = v->GetHist(i);
             for (int x=1;x <=h->GetXaxis()->GetNbins();x++){
                 for (int y = 1; y <= h->GetYaxis()->GetNbins(); y++)
@@ -2001,16 +2013,24 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
                     if (y>1) {
                         *f_vert << ",";
                     }
-                    double bincor = 1.0;
-                    if(binwidth) bincor = h->GetXaxis()->GetBinWidth(x)*h->GetYaxis()->GetBinWidth(y);
-                    if (percentage) bincor = total.GetBinContent(x,y);
-                    double frac= (h->GetBinContent(x,y)/bincor);
-                    if (!fullprecision){
-                        *f_vert<<Form("%.2f",frac);
+                    double val = h->GetBinContent(x,y) ;
+                    
+                  if (percentage){
+                    val /= total.GetBinContent(x,y);
+                  }
+                  else{
+                    if(binwidth) {double bincor = h->GetXaxis()->GetBinWidth(x)*h->GetYaxis()->GetBinWidth(y);
+                      val /= bincor;
                     }
-                    else{
-                        *f_vert<<Form("%.17e",frac);
-                    }
+                    val *= scale;
+                  }
+                  //std::cout << "check " << percentage << " " << binwidth << " " << h->GetBinContent(x,y)<< " " << val << std::endl;
+                  if (!fullprecision){
+                      *f_vert<<Form("%.3f",val);
+                  }
+                  else{
+                      *f_vert<<Form("%.17e",val);
+                  }
                     
                 }
                 *f_vert << std::endl;
@@ -2025,7 +2045,7 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
         unsigned int nunis = v->GetNHists();
         
         for (unsigned int i = 0; i< nunis; i++){
-            *f_lat << GetName() << Form(" %s_%d,",name->c_str(),i); // << std::endl;
+            *f_lat << Form("%s_%d,",name->c_str(),i); // << std::endl;
             TH2* h = v->GetHist(i);
             for (int x=1;x <=h->GetXaxis()->GetNbins();x++){
                 for (int y = 1; y <= h->GetYaxis()->GetNbins(); y++)
@@ -2034,16 +2054,23 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
                         *f_lat << ",";
                     }
                     
-                    double bincor = 1.0;
-                    if(binwidth) bincor = h->GetXaxis()->GetBinWidth(x)*h->GetYaxis()->GetBinWidth(y);
-                    if(percentage) bincor = total.GetBinContent(x,y);
-                    double frac = (h->GetBinContent(x,y)/bincor);
-                    if (!fullprecision){
-                        *f_lat<<Form("%.2f",frac);
-                    }
-                    else{
-                        *f_lat<<Form("%.17e",frac);
-                    }
+                  double val = h->GetBinContent(x,y) ;
+                  
+                if (percentage){
+                  val /= total.GetBinContent(x,y);
+                }
+                else{
+                  if(binwidth) {double bincor = h->GetXaxis()->GetBinWidth(x)*h->GetYaxis()->GetBinWidth(y);
+                    val /= bincor;
+                  }
+                  val *= scale;
+                }
+                  if (!fullprecision){
+                      *f_lat<<Form("%.3f",val);
+                  }
+                  else{
+                      *f_lat<<Form("%.17e",val);
+                  }
                     
                 }
                 *f_lat << std::endl;
@@ -2057,7 +2084,7 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
     *f_cov << " covariance " << cov_errNames.size() <<  std::endl;
     for( std::vector<std::string>::iterator name=cov_errNames.begin(); name!=cov_errNames.end(); ++name ){
         TMatrixD  v = GetSysErrorMatrix(*name);
-        *f_cov  << GetName() << Form("%s",name->c_str()) << std::endl;
+        *f_cov  << Form("%s, ",name->c_str()) << std::endl;
         //std::cout << "Try a matrix" << v[100][100] << std::endl;
       //v.Print();
         int nbins_x=GetNbinsX();

--- a/PlotUtils/MnvH2D.cxx
+++ b/PlotUtils/MnvH2D.cxx
@@ -1888,11 +1888,13 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
             }
             double widcor = 1;
             if (binwidth) widcor=GetXaxis()->GetBinWidth(x)*GetYaxis()->GetBinWidth(y);
+            
             if (!fullprecision){
                 
                 
                 
                 *f_values<<Form("%.2f",total.GetBinContent(x,y)/widcor*scale);
+                if (fractional) widcor = total.GetBinContent(x,y)*scale; // just divide by the total
                 *f_err<<Form("%.2f",err.GetBinContent(x,y)/widcor*scale);
                 *f_staterr<<Form("%.2f",stat.GetBinContent(x,y)/widcor*scale);
                 *f_syserr<<Form("%.2f",sys.GetBinContent(x,y)/widcor*scale);
@@ -1901,6 +1903,7 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
             else{
                 
                 *f_values<<Form("%.17e",total.GetBinContent(x,y)/widcor*scale);
+                if (fractional) widcor = total.GetBinContent(x,y)*scale; // just divide by the total.
                 *f_err<<Form("%.17e",total.GetBinError(x,y)/widcor*scale);
                 *f_staterr<<Form("%.17e",stat.GetBinContent(x,y)/widcor*scale);
                 *f_syserr<<Form("%.17e",sys.GetBinContent(x,y)/widcor*scale);
@@ -1966,6 +1969,7 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
             //cout << " i,j " << i << ", " << j << ", " << correlation_matrix[i][j] << ", " << binwidcorri << ", " <<  binwidcorrj << ", " << correlation_matrix[i][j]/binwidcorri/binwidcorrj << endl;
             }
             if (!binwidth) binwidcorrj = 1.0;
+            
             if (!fullprecision){
                 *f_cov<<Form("%.2f",covariance_matrix[i][j]/binwidcorri/binwidcorrj*scale*scale);   // need to include bin widths
                 *f_corr<<Form("%.4f",correlation_matrix[i][j]);   // do not include bin widths

--- a/test/MnvH1D_viewer.py
+++ b/test/MnvH1D_viewer.py
@@ -8,7 +8,8 @@ from ROOT import *
 from PlotUtils import *
 
 from array import array
-
+full = False
+binwidth = True
 norm = True
 if len(sys.argv)< 3:
   print ("viewer args are filename histname")
@@ -16,18 +17,20 @@ if len(sys.argv)< 3:
 file = sys.argv[1]
 hist = sys.argv[2]
 localdir = os.path.dirname(file)
-dir= os.path.join(localdir,os.path.basename(file)+"_csv")
+dir= os.path.join(localdir,os.path.basename(file).replace(".root","_csvdump"))
 if not os.path.exists(dir):
   os.makedirs(dir)
-# = os.path.dirname(file)
+
 
 f = TFile.Open(file,"READONLY")
-f.ls()
+#f.ls()
 
 h = MnvH1D()
 h = f.Get(hist)
-#h.Scale(1.E41)
-
+# hack to fix escape characters
+h.GetXaxis().SetTitle(h.GetXaxis().GetTitle().replace("\nu","\\nu"))
+h.GetYaxis().SetTitle(h.GetXaxis().GetTitle().replace("\nu","\\nu"))
+h.SetTitle(h.GetTitle().replace("\nu","\\nu"))
 
 fname = file[0:-5]
 o = TFile.Open(fname+"_"+hist+"_cv_bands_TH.root","RECREATE")
@@ -35,24 +38,23 @@ o = TFile.Open(fname+"_"+hist+"_cv_bands_TH.root","RECREATE")
 o.cd()
 cv = h.GetCVHistoWithStatError()
 xtra = "_binwidth"
-binwidth = True
+
 if not binwidth:
  xtra = ""
-full = False
+
 if not full:
   xtra += "_short"
 
 h.MnvH1DToCSV(h.GetName()+xtra,dir,1.E39,full,True,False,binwidth)
 cv.Write()
 
-#o = TFile.Open(fname+"_"+hist+"_cv_bands_TH.root","RECREATE")
 
 n = h.GetNVertErrorBands()
 
 names = h.GetErrorBandNames()
 
 for name in names:
-  print ("error band:", name)
+  #print ("error band:", name)
   band = h.GetVertErrorBand(name)
   hists = band.GetHists()
   bcv = MnvH1D()

--- a/test/MnvH1D_viewer.py
+++ b/test/MnvH1D_viewer.py
@@ -15,15 +15,18 @@ if len(sys.argv)< 3:
   sys.exit(1)
 file = sys.argv[1]
 hist = sys.argv[2]
- 
-dir = os.path.dirname(file)
+localdir = os.path.dirname(file)
+dir= os.path.join(localdir,os.path.basename(file)+"_csv")
+if not os.path.exists(dir):
+  os.makedirs(dir)
+# = os.path.dirname(file)
 
 f = TFile.Open(file,"READONLY")
 f.ls()
 
 h = MnvH1D()
 h = f.Get(hist)
-h.Scale(1.E41)
+#h.Scale(1.E41)
 
 
 fname = file[0:-5]
@@ -39,7 +42,7 @@ full = False
 if not full:
   xtra += "_short"
 
-h.MnvH1DToCSV(h.GetName()+xtra,dir,1.,full,True,False,binwidth)
+h.MnvH1DToCSV(h.GetName()+xtra,dir,1.E39,full,True,False,binwidth)
 cv.Write()
 
 #o = TFile.Open(fname+"_"+hist+"_cv_bands_TH.root","RECREATE")

--- a/test/MnvH2D_viewer.py
+++ b/test/MnvH2D_viewer.py
@@ -67,9 +67,10 @@ if len(sys.argv)< 3:
   print ("viewer args are filename histname")
   sys.exit(1)
 file = sys.argv[1]
-dir = "./"
-if os.path.dirname(file) != "":
-  dir = os.path.dirname(file)+"/"
+localdir = os.path.dirname(file)
+dir= os.path.join(localdir,os.path.basename(file)+"_csvdump")
+if not os.path.exists(dir):
+  os.makedirs(dir)
 hist = sys.argv[2]
 histname = hist
 newname = sys.argv[2]
@@ -89,16 +90,16 @@ f.ls()
 #f.ls()
 #h = MnvH2D()
 h = f.Get(hist)
-if h == 0:
+if h == None:
   print ("no ",sys.argv[2]," in ", sys.argv[1])
   sys.exit(1)
 print ("name is ",h.GetName(),h.GetTitle())
 
 size = h.GetBinContent(1,1)
-if h.GetBinContent(1,1) > 1.E20:
-    h.Scale(1.E-41)
-if h.GetBinContent(1,1) <  1.E-20:
-    h.Scale(1.E41)
+#if h.GetBinContent(1,1) > 1.E20:
+#    h.Scale(1.E-41)
+#if h.GetBinContent(1,1) <  1.E-20:
+#    h.Scale(1.E41)
 central = h.GetCVHistoWithStatError()
 cx = central.ProjectionX()
 cy = central.ProjectionY()
@@ -111,7 +112,7 @@ m = h.GetSysErrorMatrix("unfoldingCov")
 # MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, bool fullprecision, bool syserrors, bool percentage,bool binwidth)
 
 #print " print out CSV"
-h.MnvH2DToCSV(h.GetName()+xtra,dir,1.,full,True,False,binwidth)
+h.MnvH2DToCSV(h.GetName()+xtra,dir,1.E39,full,True,False,binwidth)
 
 #print "going to ",h.GetName()+xtra
 
@@ -122,8 +123,8 @@ b = b0
 bx = b.ProjectionX()
 by = b.ProjectionY()
 
-bx.MnvH1DToCSV(bx.GetName()+xtra,dir,1.,full,True,False,binwidth)
-by.MnvH1DToCSV(by.GetName()+xtra,dir,1.,full,True,False,binwidth)
+bx.MnvH1DToCSV(bx.GetName()+xtra,dir,1.e39,full,True,False,binwidth)
+by.MnvH1DToCSV(by.GetName()+xtra,dir,1.e39,full,True,False,binwidth)
 fname = file[0:-5]
 
 if not binwidth:

--- a/test/MnvH2D_viewer.py
+++ b/test/MnvH2D_viewer.py
@@ -94,7 +94,7 @@ if h == None:
 
 # hack to fix escape characters
 h.GetXaxis().SetTitle(h.GetXaxis().GetTitle().replace("\nu","\\nu"))
-h.GetYaxis().SetTitle(h.GetXaxis().GetTitle().replace("\nu","\\nu"))
+h.GetYaxis().SetTitle(h.GetYaxis().GetTitle().replace("\nu","\\nu"))
 h.SetTitle(h.GetTitle().replace("\nu","\\nu"))
 print ("name is ",h.GetName(),h.GetTitle())
 

--- a/test/MnvH2D_viewer.py
+++ b/test/MnvH2D_viewer.py
@@ -8,7 +8,7 @@ from PlotUtils import *
 from array import array
 
 def SyncBands2(hist):
- print (hist.GetName())
+ #print (hist.GetName())
  
  theCVhisto = MnvH2D()
  theCVHisto = hist.Clone()
@@ -34,7 +34,7 @@ def SyncBands2(hist):
 binwidth = True  # correct for bindwidth
 
 full = False # full precision
-
+Fractional = True # show individual error bands as fractions
 xtra = ""
 
 if binwidth:
@@ -68,7 +68,7 @@ if len(sys.argv)< 3:
   sys.exit(1)
 file = sys.argv[1]
 localdir = os.path.dirname(file)
-dir= os.path.join(localdir,os.path.basename(file)+"_csvdump")
+dir= os.path.join(localdir,os.path.basename(file).replace(".root","_csvdump"))
 if not os.path.exists(dir):
   os.makedirs(dir)
 hist = sys.argv[2]
@@ -79,52 +79,43 @@ if len(sys.argv)>3:
   oldname = sys.argv[3]
 if len(sys.argv)>4:
   newname = sys.argv[4]
-print ("----",hist,"-----")
+#print ("----",hist,"-----")
 xtra = ""
 if binwidth:
   xtra = "_binwidth"
 if not full:
   xtra += "_short"
 f = TFile.Open(file,"READONLY")
-f.ls()
-#f.ls()
-#h = MnvH2D()
+
 h = f.Get(hist)
 if h == None:
   print ("no ",sys.argv[2]," in ", sys.argv[1])
   sys.exit(1)
+
+# hack to fix escape characters
+h.GetXaxis().SetTitle(h.GetXaxis().GetTitle().replace("\nu","\\nu"))
+h.GetYaxis().SetTitle(h.GetXaxis().GetTitle().replace("\nu","\\nu"))
+h.SetTitle(h.GetTitle().replace("\nu","\\nu"))
 print ("name is ",h.GetName(),h.GetTitle())
 
-size = h.GetBinContent(1,1)
-#if h.GetBinContent(1,1) > 1.E20:
-#    h.Scale(1.E-41)
-#if h.GetBinContent(1,1) <  1.E-20:
-#    h.Scale(1.E41)
+
 central = h.GetCVHistoWithStatError()
+central.SetDirectory(0)
 cx = central.ProjectionX()
 cy = central.ProjectionY()
-m = h.GetSysErrorMatrix("unfoldingCov")
-#m.Print()
 
-#print "size is ", size, dir
-
-# don't do percentage for 2D
-# MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, bool fullprecision, bool syserrors, bool percentage,bool binwidth)
-
-#print " print out CSV"
-h.MnvH2DToCSV(h.GetName()+xtra,dir,1.E39,full,True,False,binwidth)
-
-#print "going to ",h.GetName()+xtra
+h.MnvH2DToCSV(h.GetName()+xtra,dir,1.E39,full,True,Fractional,binwidth)
 
 b0 = h.Clone()
+b0.SetDirectory(0)
 #b = SyncBands2(b0)
-b = b0
 #b0.Print("ALL")
-bx = b.ProjectionX()
-by = b.ProjectionY()
-
-bx.MnvH1DToCSV(bx.GetName()+xtra,dir,1.e39,full,True,False,binwidth)
-by.MnvH1DToCSV(by.GetName()+xtra,dir,1.e39,full,True,False,binwidth)
+bx = b0.ProjectionX()
+bx.GetXaxis().SetTitle(h.GetXaxis().GetTitle())
+by = b0.ProjectionY()
+by.GetXaxis().SetTitle(h.GetYaxis().GetTitle())
+bx.MnvH1DToCSV(bx.GetName()+xtra,dir,1.e39,full,True,Fractional,binwidth)
+by.MnvH1DToCSV(by.GetName()+xtra,dir,1.e39,full,True,Fractional,binwidth)
 fname = file[0:-5]
 
 if not binwidth:
@@ -136,6 +127,7 @@ o.cd()
 
 
 cv = TH2D(h.GetCVHistoWithStatError())
+cv.SetDirectory(0)
 if binwidth:
   cv.Scale(1.0,"width")
   cx.Scale(1.0,"width")


### PR DESCRIPTION
I've fixed a bunch of scaling bugs and improved the format for MnvHnVToCSV

People who use this might want to check it out. 

MAT/test/MnvH1D_viewer.py and MnvH2D_viewer.py are drivers for this that given a file and a hist make a subdirectory called file_csvdump containing csv files for most of the components of an MnvH1D or 2D.  The idea is to auto-create an ascii object for data releases.  It can optionally include all of the individual vertical error bars. 
