### PR TITLE
Add in new recobinning methods in VariableBase to allow non-square migration matrices

### DIFF
--- a/PlotUtils/MnvH1D.cxx
+++ b/PlotUtils/MnvH1D.cxx
@@ -444,7 +444,7 @@ bool MnvH1D::AddVertErrorBand( const std::string& name, const std::vector<TH1D*>
 
   // Set the ErrorBand
   fVertErrorBandMap[name] = new MnvVertErrorBand( errName, (TH1D*)this, base );
-
+ 
   return true;
 }
 
@@ -3313,11 +3313,11 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
       *f_bins<<GetXaxis()->GetBinUpEdge(i);//<<std::endl;
       // Bin width normalize if not enu when we want a total x sec
       
-      *f_values<<Form("%.2f",total.GetBinContent(i)/bincor*scale);
+      *f_values<<Form("%.4f",total.GetBinContent(i)/bincor*scale);
       if (fractional) bincor = total.GetBinContent(i)*scale;
-      *f_err<<Form("%.2f",total.GetBinError(i)/bincor*scale);
-      *f_staterr<<Form("%.2f",stat.GetBinContent(i)/bincor*scale);
-      *f_syserr<<Form("%.2f",sys.GetBinContent(i)/bincor*scale);
+      *f_err<<Form("%.4f",total.GetBinError(i)/bincor*scale);
+      *f_staterr<<Form("%.4f",stat.GetBinContent(i)/bincor*scale);
+      *f_syserr<<Form("%.4f",sys.GetBinContent(i)/bincor*scale);
       
       }
   }
@@ -3368,7 +3368,7 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
       if (this_x > 1) *f_corr << ",";
       if (this_x > 1) *f_cov << ",";
       if(!fullprecision){
-        *f_cov<<Form("%.2f",covariance_matrix[x][this_x]/binwidcorri/binwidcorrj*scale*scale);
+        *f_cov<<Form("%.4f",covariance_matrix[x][this_x]/binwidcorri/binwidcorrj*scale*scale);
         *f_corr<<Form("%.4f",correlation_matrix[x][this_x]);
       }
       else{
@@ -3425,7 +3425,7 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
         }
         double frac= (h->GetBinContent(j)/bincor);
         if (!fullprecision){
-        *f_vert<<Form("%.2f",frac);
+        *f_vert<<Form("%.4f",frac);
         }
         else{
           *f_vert<<Form("%.17e",frac);
@@ -3461,7 +3461,7 @@ void MnvH1D::MnvH1DToCSV(std::string name, std::string directory, double scale, 
           }
         double frac = (h->GetBinContent(j)/bincor);
         if (!fullprecision){
-          *f_lat<<Form("%.2f",frac);
+          *f_lat<<Form("%.4f",frac);
         }
         else{
           *f_lat<<Form("%.17e",frac);

--- a/PlotUtils/MnvH2D.cxx
+++ b/PlotUtils/MnvH2D.cxx
@@ -1893,11 +1893,11 @@ void MnvH2D::MnvH2DToCSV(std::string name, std::string directory, double scale, 
                 
                 
                 
-                *f_values<<Form("%.2f",total.GetBinContent(x,y)/widcor*scale);
+                *f_values<<Form("%.4f",total.GetBinContent(x,y)/widcor*scale);
                 if (fractional) widcor = total.GetBinContent(x,y)*scale; // just divide by the total
-                *f_err<<Form("%.2f",err.GetBinContent(x,y)/widcor*scale);
-                *f_staterr<<Form("%.2f",stat.GetBinContent(x,y)/widcor*scale);
-                *f_syserr<<Form("%.2f",sys.GetBinContent(x,y)/widcor*scale);
+                *f_err<<Form("%.4f",err.GetBinContent(x,y)/widcor*scale);
+                *f_staterr<<Form("%.4f",stat.GetBinContent(x,y)/widcor*scale);
+                *f_syserr<<Form("%.4f",sys.GetBinContent(x,y)/widcor*scale);
                 //std::cout << "syscheck" <<  sys.GetBinContent(x,y) << std::endl;
             }
             else{

--- a/PlotUtils/VariableBase.cxx
+++ b/PlotUtils/VariableBase.cxx
@@ -19,8 +19,10 @@ VariableBase<UNIVERSE>::VariableBase()
     : m_name(),
       m_xaxis_label(),
       m_binning(),
+      m_reco_binning(),
       m_pointer_to_GetRecoValue(&UNIVERSE::GetDummyVar),
-      m_pointer_to_GetTrueValue(&UNIVERSE::GetDummyVar) {}
+      m_pointer_to_GetTrueValue(&UNIVERSE::GetDummyVar),
+      m_has_reco_binning(false){}
 
 // variable binning
 template <class UNIVERSE>
@@ -33,7 +35,24 @@ VariableBase<UNIVERSE>::VariableBase(const std::string name,
       m_xaxis_label(xaxis_label),
       m_binning(GetSortedVector(binning)),
       m_pointer_to_GetRecoValue(reco_func),
-      m_pointer_to_GetTrueValue(true_func) {}
+      m_pointer_to_GetTrueValue(true_func),
+      m_has_reco_binning(false){}
+
+
+template <class UNIVERSE>  // with different reco binning
+VariableBase<UNIVERSE>::VariableBase(const std::string name,
+                                     const std::string xaxis_label,
+                                     const std::vector<double> binning,
+                                     const std::vector<double> reco_binning,
+                                     PointerToCVUniverseFunction reco_func,
+                                     PointerToCVUniverseFunction true_func)
+    : m_name(name),
+      m_xaxis_label(xaxis_label),
+      m_binning(GetSortedVector(binning)),
+      m_reco_binning(GetSortedVector(reco_binning)),
+      m_pointer_to_GetRecoValue(reco_func),
+      m_pointer_to_GetTrueValue(true_func),
+      m_has_reco_binning(true){}
 
 // uniform binning
 template <class UNIVERSE>
@@ -47,7 +66,25 @@ VariableBase<UNIVERSE>::VariableBase(const std::string name,
       m_xaxis_label(xaxis_label),
       m_binning(MakeUniformBinning(nbins, xmin, xmax)),
       m_pointer_to_GetRecoValue(reco_func),
-      m_pointer_to_GetTrueValue(true_func) {}
+      m_pointer_to_GetTrueValue(true_func),
+      m_has_reco_binning(false){}
+
+template <class UNIVERSE>
+VariableBase<UNIVERSE>::VariableBase(const std::string name,
+                                     const std::string xaxis_label,
+                                     const int nbins, const double xmin,
+                                     const double xmax,
+                                     const int nrecobins, const double xminreco,
+                                     const double xmaxreco,
+                                     PointerToCVUniverseFunction reco_func,
+                                     PointerToCVUniverseFunction true_func)
+    : m_name(name),
+      m_xaxis_label(xaxis_label),
+      m_binning(MakeUniformBinning(nbins, xmin, xmax)),
+      m_reco_binning(MakeUniformBinning(nrecobins, xminreco, xmaxreco)),
+      m_pointer_to_GetRecoValue(reco_func),
+      m_pointer_to_GetTrueValue(true_func),
+      m_has_reco_binning(true){}
 
 //==============================================================================
 // Set/Get
@@ -68,6 +105,12 @@ int VariableBase<UNIVERSE>::GetNBins() const {
 }
 
 template <class UNIVERSE>
+int VariableBase<UNIVERSE>::GetNRecoBins() const {
+    if (!m_has_reco_binning) return m_binning.size() - 1;
+  return m_reco_binning.size() - 1;
+}
+
+template <class UNIVERSE>
 void VariableBase<UNIVERSE>::PrintBinning() const {
   std::cout << GetName() << " binning: ";
   for (const auto b : m_binning) std::cout << b << " ";
@@ -75,8 +118,27 @@ void VariableBase<UNIVERSE>::PrintBinning() const {
 }
 
 template <class UNIVERSE>
+void VariableBase<UNIVERSE>::PrintRecoBinning() const {
+    if (!m_has_reco_binning) {
+        std::cout << GetName() << " reco binning same as true";
+        for (const auto b : m_binning) std::cout << b << " ";
+        std::cout << "\n";
+        return;
+    }
+  std::cout << GetName() << " reco binning: ";
+  for (const auto b : m_reco_binning) std::cout << b << " ";
+  std::cout << "\n";
+}
+
+template <class UNIVERSE>
 std::vector<double> VariableBase<UNIVERSE>::GetBinVec() const {
   return m_binning;
+}
+
+template <class UNIVERSE>
+std::vector<double> VariableBase<UNIVERSE>::GetRecoBinVec() const {
+    if (!m_has_reco_binning) return m_binning;
+    return m_reco_binning;
 }
 
 //==============================================================================
@@ -108,6 +170,25 @@ std::vector<double> VariableBase<UNIVERSE>::MakeUniformBinning(
   const int size = sizeof(arr) / sizeof(*arr);
   std::vector<double> ret(arr, arr + size);
   return ret;
+}
+
+template <class UNIVERSE>
+std::vector<double> VariableBase<UNIVERSE>::SplitBinning(
+    const std::vector<double> v, const int split) {
+  std::vector<double> newv;
+  std::vector<double> oldv = GetSortedVector(v);
+  for (int i = 0; i < oldv.size()-1; ++i){
+    double diff = oldv[i+1]-oldv[i];
+    newv.push_back(oldv[i]);
+    newv.push_back(oldv[i]+diff/double(split));
+  }
+  newv.push_back(newv[oldv.size()-1]);
+  std::cout << "split vector " ;
+  for (auto vi:newv){
+    std::cout << vi << "," ;
+  }
+  std::cout << std::endl;
+  return newv;
 }
 
 template <class UNIVERSE>

--- a/PlotUtils/VariableBase.h
+++ b/PlotUtils/VariableBase.h
@@ -65,7 +65,7 @@ class VariableBase {
   int GetNBins() const;
   int GetNRecoBins() const;
   bool HasRecoBinning (){ return m_has_reco_binning;} // flag to tell if you need to bother with reco bins
-  void SetRecoBinning (const bool has){m_has_reco_binning = has;}
+  void SetRecoBinning (const bool has){m_has_reco_binning = has;}
   std::vector<double> GetBinVec() const;
   std::vector<double> GetRecoBinVec() const;
   void PrintBinning() const;

--- a/PlotUtils/VariableBase.h
+++ b/PlotUtils/VariableBase.h
@@ -26,6 +26,7 @@ class VariableBase {
   // * returns a double,
   // * is a member of UNIVERSE, and
   // * acts on a `this` which is a const reference to a UNIVERSE.
+  // HMS 8-10-2022 add support for different true and reco binning
   typedef std::function<double(const UNIVERSE&)> PointerToCVUniverseFunction;
 
  public:
@@ -37,10 +38,22 @@ class VariableBase {
                const std::vector<double> binning,
                PointerToCVUniverseFunction reco_func = &UNIVERSE::GetDummyVar,
                PointerToCVUniverseFunction true_func = &UNIVERSE::GetDummyVar);
+  
+  VariableBase(const std::string name, const std::string xaxis_label,
+               const std::vector<double> binning,
+               const std::vector<double> reco_binning,
+               PointerToCVUniverseFunction reco_func = &UNIVERSE::GetDummyVar,
+               PointerToCVUniverseFunction true_func = &UNIVERSE::GetDummyVar);
 
   // uniform binning
   VariableBase(const std::string name, const std::string xaxis_label,
                const int nbins, const double xmin, const double xmax,
+               PointerToCVUniverseFunction reco_func = &UNIVERSE::GetDummyVar,
+               PointerToCVUniverseFunction true_func = &UNIVERSE::GetDummyVar);
+  
+  VariableBase(const std::string name, const std::string xaxis_label,
+               const int nbins, const double xmin, const double xmax,
+               const int nrecobins, const double xminreco, const double xmaxreco,
                PointerToCVUniverseFunction reco_func = &UNIVERSE::GetDummyVar,
                PointerToCVUniverseFunction true_func = &UNIVERSE::GetDummyVar);
 
@@ -50,8 +63,13 @@ class VariableBase {
   std::string GetName() const;
   std::string GetAxisLabel() const;
   int GetNBins() const;
+  int GetNRecoBins() const;
+  bool HasRecoBinning (){ return m_has_reco_binning;} // flag to tell if you need to bother with reco bins
+  bool SetRecoBinning (const bool has){m_has_reco_binning = has;}
   std::vector<double> GetBinVec() const;
+  std::vector<double> GetRecoBinVec() const;
   void PrintBinning() const;
+  void PrintRecoBinning() const;
 
   //============================================================================
   // GetValue
@@ -64,7 +82,9 @@ class VariableBase {
   // hms - make protected so can overload in derived classes without introducing dependencies
   std::string m_xaxis_label;
   std::string m_name;
+  bool m_has_reco_binning;
   std::vector<double> m_binning;
+  std::vector<double> m_reco_binning;
   PointerToCVUniverseFunction m_pointer_to_GetRecoValue;
   PointerToCVUniverseFunction m_pointer_to_GetTrueValue;
 
@@ -77,6 +97,9 @@ class VariableBase {
   // Helper functions
   std::vector<double> MakeUniformBinning(const int nbins, const double min,
                                          const double max);
+  
+  std::vector<double> SplitBinning(const std::vector<double> binning, const int split);
+  
   std::vector<double> GetSortedVector(const std::vector<double>& vin);
 };
 #endif  // __CINT__

--- a/PlotUtils/VariableBase.h
+++ b/PlotUtils/VariableBase.h
@@ -65,7 +65,7 @@ class VariableBase {
   int GetNBins() const;
   int GetNRecoBins() const;
   bool HasRecoBinning (){ return m_has_reco_binning;} // flag to tell if you need to bother with reco bins
-  bool SetRecoBinning (const bool has){m_has_reco_binning = has;}
+  void SetRecoBinning (const bool has){m_has_reco_binning = has;}
   std::vector<double> GetBinVec() const;
   std::vector<double> GetRecoBinVec() const;
   void PrintBinning() const;


### PR DESCRIPTION
Added a recobinning member:

  // HMS 8-10-2022 add support for different true and reco binning
             
  int GetNRecoBins() const;
  bool HasRecoBinning (){ return m_has_reco_binning;} // flag to tell if you need to bother with reco bins
  void SetRecoBinning (const bool has){m_has_reco_binning = has;}
  std::vector<double> GetRecoBinVec() const;
  void PrintRecoBinning() const;
  bool m_has_reco_binning;
  std::vector<double> m_reco_binning;

and new constructors which take 2 binnings. 

if you don't call this, it doesn't do anything. 